### PR TITLE
Improved Readme for Windows.

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,9 +9,9 @@ A very simple web based note solution that's designed to serve as my second brai
 To start the tool simply clone the repo and then run PHP in server mode (for development and testing only) from the repo's root directory.
 
 ```
-git clone git@github.com:codazoda/nolific.git
+git clone https://github.com/codazoda/nolific.git
 cd nolific
-php -S 0:8001
+php -S localhost:8001
 ```
 
 Then open your web browser and point it to `http://localhost:8001`. The default username is `admin` and the default password is also `admin`.


### PR DESCRIPTION
I'm trying to run this on windows.  
The readme had 2 little issues: 
First cloning from github with ssh doesn't work out of the box: 
![image](https://user-images.githubusercontent.com/18743295/151875721-840c092f-dc1c-4fda-9041-bce3da3a77d4.png)

So I switched to a http clone.

Then the ip `0` used to start the server is not a valid IP, which fail on start on windows.